### PR TITLE
Pointer resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.1.2
 
-- Add incremental pointer-size resize for `Map` and `Enumeration`. The new `beginResize` / `stepResize` / `completeResize` API migrates an existing trie to a different `pointer_size` over multiple message executions, sharing the underlying `Region`s with the original.
+- In-place ability to change the pointer-size (see README)
+- **Breaking**: Internal representation is not compatible with 0.1.1
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Stable-trie changelog
 
+## 0.1.2
+
+- Add incremental pointer-size resize for `Map` and `Enumeration`. The new `beginResize` / `stepResize` / `completeResize` API migrates an existing trie to a different `pointer_size` over multiple message executions, sharing the underlying `Region`s with the original.
+
 ## 0.1.1
 
 - Add promtracker integration with `toValue` function

--- a/README.md
+++ b/README.md
@@ -358,6 +358,70 @@ Per scrape the `Value` calls `memoryStats()` once and emits five samples in thre
 
 **Version compatibility:** `toValue()` is designed against the `Value` / `Metric` shapes introduced in **`promtracker >= 1.0.1`** (the `mixins/http`-shaped API). The older 0.5.x releases used different shapes and will not type-check.
 
+### Pointer-size resize
+
+The `pointer_size` chosen at construction caps how many entries a trie can hold (`max_address = 2 ** (pointer_size * 8 - 1)`). An existing trie can be migrated in place to a different pointer size — typically to shrink the address space once a working set is known, or to grow it before hitting `LimitExceeded`. Pointer values encode node/leaf _indices_ (not byte offsets), so every pointer's numeric value is preserved across the migration; only the byte width of each slot changes.
+
+The work is **incremental** and meant to span multiple IC messages — `stepResize` does one batch of nodes per call:
+
+```motoko
+import Map "mo:stable-trie/Map";
+
+persistent actor {
+  var m : Map.Map = Map.empty({
+    pointer_size = 4;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 8;
+    value_size = 4;
+  });
+  var resizing : ?Map.ResizeState = null;
+
+  // 1. Start the migration.
+  public func startResize(new_pointer_size : Nat) : async Bool {
+    switch (m.beginResize(new_pointer_size)) {
+      case (?s) { resizing := ?s; true };
+      case null false; // refused — see below
+    };
+  };
+
+  // 2. Drive the migration over as many messages as needed. The caller
+  //    invokes this repeatedly (e.g. via a heartbeat or a timer) until
+  //    it returns `true`.
+  public func continueResize(batch : Nat) : async Bool {
+    switch (resizing) {
+      case null true; // nothing in progress
+      case (?state) {
+        if (Map.stepResize(state, batch)) {
+          // 3. Done — swap in the new trie.
+          m := Map.completeResize(state);
+          resizing := null;
+          true;
+        } else { false };
+      };
+    };
+  };
+};
+
+```
+
+**Caller responsibilities** while a migration is in progress:
+
+- Hold the trie in a `var` (so you can reassign it to the value `completeResize` returns).
+- Keep the `ResizeState` reachable across messages (typically a `var resizing : ?ResizeState`). The state is stable and survives canister upgrades.
+- Between `beginResize` and `completeResize`, do **NOT** read or write through the original trie reference. The regions are partially re-encoded between calls; the old layout's offsets no longer describe what's at those bytes.
+
+`beginResize` returns `null` (refuses to start) when:
+
+- `new_pointer_size` isn't one of `1, 2, 4, 5, 6, 8`;
+- `new_pointer_size == self.pointer_size` (no migration to do);
+- the current `node_count` or `leaf_count` wouldn't fit in the new pointer space;
+- the migration would force `leaf_size` to change (Map padding case where `new_pointer_size > leaf_size`).
+
+The leaves region is not touched by the migration — the only re-encoding happens in the nodes region. Internal-node free-list links and freed leaves both survive the migration unchanged.
+
+Choosing `batch`: each batch processes that many nodes, with cost roughly `aridity × pointer_size` stable-memory operations per node. Batches in the low thousands are typically safe within an IC update message budget; tune for your specific aridity and how much other work the message does.
+
 ### Build & test
 
 Run:

--- a/example/mops.toml
+++ b/example/mops.toml
@@ -7,4 +7,4 @@ promtracker = "1.0.1"
 core = "2.5.0"
 
 [toolchain]
-moc = "1.8.2"
+moc = "1.9.0"

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-trie"
-version = "0.1.1"
+version = "0.1.2"
 description = "Stable-memory trie-based key-value map"
 repository = "https://github.com/research-ag/stable-trie"
 keywords = [ "set", "enumeration", "lookup", "bijective", "key-value" ]
@@ -18,6 +18,6 @@ prng = "0.2.0"
 moc = "1.0.0"
 
 [toolchain]
-moc = "1.8.2"
+moc = "1.9.0"
 wasmtime = "44.0.1"
 pocket-ic = "9.0.3"

--- a/src/Enumeration.mo
+++ b/src/Enumeration.mo
@@ -341,4 +341,39 @@ module {
   /// (the `Value` / `Metric` shapes the result targets are the ones
   /// introduced in 1.0.x; 0.5.x is not supported).
   public let toValue : (self : Enumeration) -> Trie.Value = Trie.toValue;
+
+  // ─── Pointer-size resize (incremental) ────────────────────────────────────
+  //
+  // Migrate an existing Enumeration to a different pointer_size. The work
+  // spans multiple messages: `beginResize` validates and prepares;
+  // `stepResize` does a batch and is called repeatedly until it returns
+  // `true`; `completeResize` returns the new Enumeration. During the
+  // migration the caller must NOT read or write through the original
+  // Enumeration reference.
+
+  /// State carried across calls of an incremental pointer-size resize.
+  /// See `Trie.ResizeState`.
+  public type ResizeState = Trie.ResizeState;
+
+  /// `beginResize(self : Enumeration, new_pointer_size : Nat) : ?ResizeState`
+  ///
+  /// Start an incremental pointer-size migration. Returns `null` if the
+  /// resize cannot proceed (invalid pointer size; current node/leaf count
+  /// wouldn't fit; the change would alter `leaf_size`).
+  public let beginResize : (self : Enumeration, new_pointer_size : Nat) -> ?ResizeState = Trie.beginResize;
+
+  /// `stepResize(state : ResizeState, batch_size : Nat) : Bool`
+  ///
+  /// Migrate up to `batch_size` nodes. Returns `true` when every node has
+  /// been migrated. Once `true` has been returned, call `completeResize`
+  /// to obtain the new Enumeration.
+  public let stepResize : (state : ResizeState, batch_size : Nat) -> Bool = Trie.stepResize;
+
+  /// `completeResize(state : ResizeState) : Enumeration`
+  ///
+  /// Assemble the new Enumeration from a completed resize. Traps if
+  /// `stepResize` has not yet returned `true`. The returned Enumeration
+  /// shares the now-rewritten regions with the original; the caller must
+  /// stop using the original reference.
+  public let completeResize : (state : ResizeState) -> Enumeration = Trie.completeResize;
 };

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -352,4 +352,43 @@ module {
   /// (the `Value` / `Metric` shapes the result targets are the ones
   /// introduced in 1.0.x; 0.5.x is not supported).
   public let toValue : (self : Map) -> Trie.Value = Trie.toValue;
+
+  // ─── Pointer-size resize (incremental) ────────────────────────────────────
+  //
+  // Migrate an existing Map to a different pointer_size. The work spans
+  // multiple messages: `beginResize` validates and prepares; `stepResize`
+  // does a batch and is called repeatedly until it returns `true`;
+  // `completeResize` returns the new Map. During the migration the caller
+  // must NOT read or write through the original Map reference — both the
+  // old and new layouts share the same region bytes, which are partially
+  // re-encoded between calls.
+
+  /// State carried across calls of an incremental pointer-size resize.
+  /// See `Trie.ResizeState`.
+  public type ResizeState = Trie.ResizeState;
+
+  /// `beginResize(self : Map, new_pointer_size : Nat) : ?ResizeState`
+  ///
+  /// Start an incremental pointer-size migration. Returns `null` if the
+  /// resize cannot proceed (invalid pointer size; current node/leaf count
+  /// wouldn't fit; the change would alter `leaf_size`; or growing while
+  /// the empty-leaves free list is non-empty). On success, no nodes have
+  /// been migrated yet — call `stepResize` to do the work.
+  public let beginResize : (self : Map, new_pointer_size : Nat) -> ?ResizeState = Trie.beginResize;
+
+  /// `stepResize(state : ResizeState, batch_size : Nat) : Bool`
+  ///
+  /// Migrate up to `batch_size` nodes. Returns `true` when every node has
+  /// been migrated; further calls then become no-ops that still return
+  /// `true`. Once `true` has been returned, call `completeResize` to
+  /// obtain the new Map.
+  public let stepResize : (state : ResizeState, batch_size : Nat) -> Bool = Trie.stepResize;
+
+  /// `completeResize(state : ResizeState) : Map`
+  ///
+  /// Assemble the new Map from a completed resize. Traps if `stepResize`
+  /// has not yet returned `true`. The returned Map shares the now-rewritten
+  /// regions with the original; the caller must stop using the original
+  /// reference (typically by holding the Map in a `var` and reassigning).
+  public let completeResize : (state : ResizeState) -> Map = Trie.completeResize;
 };

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -42,6 +42,7 @@
 
 import Nat "mo:core/Nat";
 import _Nat64 "mo:core/Nat64"; // enables `Nat64.toNat()` dot notation
+import _Region "mo:core/Region"; // enables `region.storeBlob(...)` dot notation
 import Result "mo:core/Result";
 import Types "mo:core/Types";
 
@@ -271,6 +272,11 @@ module {
       let leaf = node >> 1;
       if (Layout.getKey(self, leaf) == key) {
         let v = if (ret) ?Layout.getValue(self, leaf) else null;
+        // Zero the leaf so that the only non-zero bytes after the push are
+        // the chain link (or none, when the list was empty — see
+        // LinkedList.push). Symmetric with the per-slot `setChild(..., 0)`
+        // for collapsed internal nodes in the `#onlyLeaf` branch below.
+        self.leaves_region.storeBlob(Layout.getLeafOffset(self, leaf), self.zero_leaf);
         Trie.pushEmptyLeaf(self, leaf);
         return (v, true, 0 : Nat64);
       } else {

--- a/src/internal/layout.mo
+++ b/src/internal/layout.mo
@@ -67,6 +67,13 @@ module {
     offset_base : Nat64;
     padding : Nat64;
     empty_values : Bool;
+    /// A precomputed `leaf_size`-byte all-zero blob. `Map.removeRec` writes
+    /// this over a leaf before pushing it onto `empty_leaves_list`, so
+    /// that every freed leaf is fully zero in the region (only the chain
+    /// link, if any, is then written by `LinkedList.push`). Symmetric with
+    /// the per-slot `setChild(..., 0)` that `Map.removeRec` already does
+    /// for collapsed internal nodes before `pushEmptyNode`.
+    zero_leaf : Blob;
     empty_nodes_list : LinkedList.LinkedList;
     empty_leaves_list : LinkedList.LinkedList;
     var leaf_count : Nat64;

--- a/src/internal/linked-list.mo
+++ b/src/internal/linked-list.mo
@@ -7,8 +7,18 @@
 ///
 /// The chain lives inside the freed items themselves: each freed item's slot
 /// (its first `pointer_size` bytes, at byte offset `offset_base + i*item_size`)
-/// holds the index of the next freed item, or the all-ones sentinel for the
-/// tail of the chain.
+/// holds the index of the next freed item below it on the stack. The bottom
+/// item carries no chain link — its slot stays all-zero. The signal for
+/// "list is empty" is `count == 0`, not a stored sentinel; no
+/// pointer-size-dependent value is ever written into the region by this
+/// module, which makes the structure trivially survive a `pointer_size`
+/// migration of the surrounding trie.
+///
+/// Items pushed onto the list MUST be all-zero before the push (apart from
+/// the chain-link slot, which `push` overwrites). The caller is responsible
+/// for clearing the item: `Map.removeRec` does this via
+/// `Layout.setChild(node, slot, 0)` before `pushEmptyNode`, and via
+/// `storeBlob(..., zero_leaf)` before `pushEmptyLeaf`.
 ///
 /// Implemented as a plain mutable record plus module-level functions that take
 /// the record as their first argument `self`, so callers use dot-notation:
@@ -27,11 +37,12 @@ module {
   ///
   /// - `offset_base`, `item_size`, `pointer_size` are fixed at construction.
   /// - `loadMask` is precomputed from `pointer_size` (mask of `pointer_size*8`
-  ///   bits). It doubles as the empty-list sentinel: every valid index is
-  ///   `< 2 ** (pointer_size*8 - 1) < loadMask`, so the sentinel can never
-  ///   collide with a real item index.
-  /// - `count` is the list length; `last_empty_item` is the head index (or the
-  ///   sentinel when the list is empty).
+  ///   bits). Used by `pop` to mask the loaded `Nat64` down to the actual
+  ///   chain-link width. NOT used as an empty-list sentinel — that role is
+  ///   played by `count == 0`.
+  /// - `count` is the list length; `last_empty_item` is the head index when
+  ///   `count > 0`. When `count == 0`, `last_empty_item` is just a
+  ///   placeholder (set to `0` by `empty` and by `pop` when the list drains).
   public type LinkedList = {
     offset_base : Nat64;
     item_size : Nat64;
@@ -55,7 +66,7 @@ module {
       pointer_size = nat64toNat(pointer_size);
       loadMask;
       var count = 0;
-      var last_empty_item = loadMask; // empty: head == sentinel
+      var last_empty_item = 0; // placeholder while count == 0
     };
   };
 
@@ -90,24 +101,42 @@ module {
     };
   };
 
-  /// Add a deleted item (by index) to the list. Requires that the item slot
-  /// be large enough to hold a chain link, i.e. the `item_size` chosen at
-  /// construction is at least `pointer_size`; otherwise the link spills into
-  /// the next item's slot.
+  /// Add a deleted item (by index) to the list. Caller MUST hand in an
+  /// all-zero item slot; this function writes only the chain link (and only
+  /// when the list was already non-empty — the bottom item has no chain
+  /// link, its slot stays all-zero).
+  ///
+  /// Requires `item_size >= pointer_size`; otherwise the link would spill
+  /// into the next item's slot.
   public func push(self : LinkedList, region : Region.Region, item : Nat64) {
-    storePointer(region, self.pointer_size, slotOffset(self, item), self.last_empty_item);
+    if (self.count > 0) {
+      // Non-empty list: link the new top down to what used to be on top.
+      storePointer(region, self.pointer_size, slotOffset(self, item), self.last_empty_item);
+    };
+    // Empty list: skip the write — the item is already all-zero by
+    // precondition, and the all-zero state is the bottom-of-list marker.
     self.last_empty_item := item;
     self.count += 1;
   };
 
   /// Pop the most-recently-freed item (by index), or `null` if empty.
+  /// The popped item's chain-link slot is cleared on the way out so that
+  /// the item is fully reusable as an all-zero block.
   public func pop(self : LinkedList, region : Region.Region) : ?Nat64 {
-    if (self.last_empty_item == self.loadMask) return null;
+    if (self.count == 0) return null;
 
     let ret = self.last_empty_item;
-    self.last_empty_item := loadPointer(region, slotOffset(self, self.last_empty_item), self.loadMask);
-    storePointer(region, self.pointer_size, slotOffset(self, ret), 0);
     self.count -= 1;
+    if (self.count > 0) {
+      // Read the chain link to find the next-to-pop.
+      self.last_empty_item := loadPointer(region, slotOffset(self, ret), self.loadMask);
+    } else {
+      // Just popped the bottom; restore the placeholder.
+      self.last_empty_item := 0;
+    };
+    // Clear the popped item's chain-link slot (idempotent zero-write when
+    // ret was the bottom — its slot is already 0).
+    storePointer(region, self.pointer_size, slotOffset(self, ret), 0);
     ?ret;
   };
 };

--- a/src/internal/trie.mo
+++ b/src/internal/trie.mo
@@ -11,6 +11,8 @@
 /// (`trie.put_(...)`, `trie.lookup(...)`, etc.) which Motoko resolves to the
 /// corresponding module-level function.
 
+import Array "mo:core/Array";
+import Blob "mo:core/Blob";
 import Nat_ "mo:core/Nat";
 import Nat16 "mo:core/Nat16"; // bitcountTrailingZero
 import Nat64 "mo:core/Nat64"; // bitcountTrailingZero
@@ -169,6 +171,7 @@ module {
       offset_base;
       padding;
       empty_values = args.value_size == 0;
+      zero_leaf = Blob.fromArray(Array.tabulate<Nat8>(args.leaf_size, func(_) = 0));
       empty_nodes_list = LinkedList.empty(offset_base, node_size, pointer_size_);
       empty_leaves_list = LinkedList.empty(0, leaf_size, pointer_size_);
       var leaf_count = 0 : Nat64;
@@ -619,9 +622,14 @@ module {
     root_bitlength : Nat16;
     leaf_size : Nat64;
     empty_values : Bool;
-    // Free-list state (preserved verbatim — empty_nodes_list links are
-    // re-encoded by the per-node rewrite, since they live at the start
-    // of each freed node).
+    zero_leaf : Blob;
+    // Free-list state, captured verbatim. For the nodes list, the per-node
+    // rewrite re-encodes the chain links (they live at the start of each
+    // freed node, which the sweep visits). For the leaves list, no
+    // re-encoding is needed: the LinkedList never writes a pointer-size-
+    // dependent sentinel into the region (count==0 is the empty signal),
+    // so the in-region bytes are agnostic to the new pointer width as
+    // long as the head index itself fits in it (which we checked above).
     empty_nodes_count : Nat;
     empty_nodes_last : Nat64;
     empty_leaves_count : Nat;
@@ -642,13 +650,20 @@ module {
   /// - the new pointer space is too small to address the current
   ///   `node_count` or `leaf_count`;
   /// - the new pointer size would change `leaf_size` (Map padding case,
-  ///   i.e. `new_pointer_size > leaf_size`);
-  /// - growing while the empty-leaves free list is non-empty (the
-  ///   chain links inside leaves would need re-encoding; not currently
-  ///   handled).
+  ///   i.e. `new_pointer_size > leaf_size`).
   ///
   /// On success, the region is grown if needed (for the growing case)
   /// and a `ResizeState` is returned. No nodes have been migrated yet.
+  ///
+  /// The leaves region is NOT touched by the resize. Freed leaves in
+  /// `empty_leaves_list` survive the migration unchanged because (a)
+  /// they are all-zero except for their chain-link slot (the caller
+  /// zeros them before push), and (b) `LinkedList` does not depend on
+  /// any pointer-size-encoded sentinel inside the region — `count` is
+  /// the empty signal, and the chain link of the bottom item is just
+  /// zero. So a free-list entry encoded under the old layout decodes
+  /// correctly under the new layout as long as the index value itself
+  /// fits in the new pointer width.
   public func beginResize(self : StableTrie, new_pointer_size : Nat) : ?ResizeState {
     let valid = switch (new_pointer_size) {
       case (1 or 2 or 4 or 5 or 6 or 8) true;
@@ -667,10 +682,6 @@ module {
     if (new_pointer_size_ > self.leaf_size) return null;
 
     let shrinking = new_pointer_size < self.pointer_size;
-
-    // Growing with a non-empty leaves free list would require rewriting
-    // the chain links inside freed leaves; not handled here.
-    if (not shrinking and self.empty_leaves_list.count > 0) return null;
 
     let new_node_size = self.aridity_ *% new_pointer_size_;
     let new_root_size = self.root_aridity_ *% new_pointer_size_;
@@ -724,17 +735,14 @@ module {
       root_bitlength = self.root_bitlength;
       leaf_size = self.leaf_size;
       empty_values = self.empty_values;
+      zero_leaf = self.zero_leaf;
       empty_nodes_count = self.empty_nodes_list.count;
-      // The free-list "empty" sentinel is `last_empty_item == loadMask`, and
-      // loadMask depends on pointer_size. A list that's empty under the old
-      // layout has its head set to the OLD loadMask. After the resize the
-      // new list will compare against the NEW loadMask, so we translate the
-      // sentinel here. Real (in-range) indices are preserved verbatim — they
-      // already fit in the new pointer width (we checked node_count and
-      // leaf_count above).
-      empty_nodes_last = if (self.empty_nodes_list.last_empty_item == self.loadMask) new_loadMask else self.empty_nodes_list.last_empty_item;
+      // No sentinel translation needed: `last_empty_item` is either a real
+      // index (preserved verbatim) when count > 0, or the placeholder 0
+      // when count == 0 — neither depends on pointer_size.
+      empty_nodes_last = self.empty_nodes_list.last_empty_item;
       empty_leaves_count = self.empty_leaves_list.count;
-      empty_leaves_last = if (self.empty_leaves_list.last_empty_item == self.loadMask) new_loadMask else self.empty_leaves_list.last_empty_item;
+      empty_leaves_last = self.empty_leaves_list.last_empty_item;
       leaves_freeSpace = self.leaves_freeSpace;
       shrinking;
       var processed = 0 : Nat64;
@@ -833,6 +841,7 @@ module {
       offset_base = state.new_offset_base;
       padding = state.new_padding;
       empty_values = state.empty_values;
+      zero_leaf = state.zero_leaf;
       empty_nodes_list = {
         offset_base = state.new_offset_base;
         item_size = state.new_node_size;

--- a/src/internal/trie.mo
+++ b/src/internal/trie.mo
@@ -538,7 +538,7 @@ module {
   /// against this function.
   public func toValue(self : StableTrie) : Value {
     return {
-      read = func() : [Metric] = self.memoryStats() |> [
+      read = func() : [Metric] = memoryStats(self) |> [
         ("stable_trie_node_count", "kind=\"total\"", _.total_node_count),
         ("stable_trie_leaf_count", "kind=\"total\"", _.total_leaf_count),
         ("stable_trie_node_count", "kind=\"used\"", _.used_node_count),

--- a/src/internal/trie.mo
+++ b/src/internal/trie.mo
@@ -32,6 +32,9 @@ module {
 
   // down conversions
   let nat16to8 = Prim.nat16ToNat8;
+  let nat32to16 = Prim.nat32ToNat16;
+  let nat64to32 = Prim.nat64ToNat32;
+  let natWrap8 = Prim.intToNat8Wrap;
 
   /// Constructor arguments shared by `Enumeration` and `Map`. The public
   /// `empty()` in those modules documents the fields in user-facing terms.
@@ -539,6 +542,342 @@ module {
         ("stable_trie_leaf_count", "kind=\"used\"", _.used_leaf_count),
         ("stable_trie_byte_size", "", _.byte_size),
       ];
+    };
+  };
+
+  // ─── Incremental pointer-size resize ───────────────────────────────────────
+  //
+  // The pointer width of a trie can be migrated to a different value (e.g.
+  // 4 → 2 to shrink the address space once it's known the trie won't grow
+  // further, or 2 → 4 to make room for more entries). Pointer values
+  // encode node/leaf *indices*, not byte offsets, so the numeric value of
+  // every pointer is preserved across the resize — only the byte width
+  // changes.
+  //
+  // The rewrite happens in place on the existing nodes region:
+  //
+  // - Shrinking (new_ps < old_ps): each node is read at its old position
+  //   with the old width and written at its new (leftward) position with
+  //   the new width. Nodes are processed left-to-right.
+  //
+  // - Growing (new_ps > old_ps): the region is grown first if needed,
+  //   then nodes are processed right-to-left, each read at its old
+  //   position and written at its new (rightward) position.
+  //
+  // The work is incremental: `beginResize` produces a stable `ResizeState`,
+  // `stepResize` does up to `batch_size` nodes per call and returns `true`
+  // when the last node has been processed, and `completeResize` returns
+  // the new `StableTrie` sharing the now-rewritten regions. The caller
+  // is responsible for:
+  //
+  // - storing the original trie reference in a `var`, so it can be
+  //   reassigned to the new trie after `completeResize`;
+  // - keeping the `ResizeState` reachable across messages (typically a
+  //   `var resizing : ?ResizeState`);
+  // - NOT performing any read or write through the original trie
+  //   reference between `beginResize` and `completeResize` — both the
+  //   old and new layouts use the same region bytes, and the bytes are
+  //   neither old-shape nor new-shape during the migration.
+
+  /// State carried across calls of an incremental pointer-size resize.
+  ///
+  /// All fields are stable types so the state survives canister upgrades.
+  public type ResizeState = {
+    nodes_region : Region.Region;
+    leaves_region : Region.Region;
+    node_count : Nat64;
+    leaf_count : Nat64;
+    // Old layout snapshot — used to decode the still-untouched part of
+    // the nodes region.
+    old_pointer_size : Nat;
+    old_pointer_size_ : Nat64;
+    old_node_size : Nat64;
+    old_offset_base : Nat64;
+    old_loadMask : Nat64;
+    // New layout snapshot — used to write the migrated part, and to
+    // construct the new StableTrie in `completeResize`.
+    new_pointer_size : Nat;
+    new_pointer_size_ : Nat64;
+    new_node_size : Nat64;
+    new_root_size : Nat64;
+    new_offset_base : Nat64;
+    new_loadMask : Nat64;
+    new_max_address : Nat64;
+    new_safe_node_bound : Nat64;
+    new_padding : Nat64;
+    new_nodes_freeSpace : Nat64;
+    // Unchanged layout values (carried verbatim into the new StableTrie).
+    key_size : Nat;
+    value_size : Nat;
+    aridity_ : Nat64;
+    key_size_ : Nat64;
+    root_aridity_ : Nat64;
+    bitlength : Nat16;
+    bitshift : Nat8;
+    max_chain_depth : Nat64;
+    root_bitlength_ : Nat64;
+    root_bitlength : Nat16;
+    leaf_size : Nat64;
+    empty_values : Bool;
+    // Free-list state (preserved verbatim — empty_nodes_list links are
+    // re-encoded by the per-node rewrite, since they live at the start
+    // of each freed node).
+    empty_nodes_count : Nat;
+    empty_nodes_last : Nat64;
+    empty_leaves_count : Nat;
+    empty_leaves_last : Nat64;
+    leaves_freeSpace : Nat64;
+    // Direction of the migration.
+    shrinking : Bool;
+    // Number of nodes already migrated (0 .. node_count). When equal to
+    // node_count, the resize is done and `completeResize` may be called.
+    var processed : Nat64;
+  };
+
+  /// Begin an incremental pointer-size migration. Returns `null` if the
+  /// resize cannot proceed:
+  ///
+  /// - `new_pointer_size` is not one of `1, 2, 4, 5, 6, 8`;
+  /// - `new_pointer_size == self.pointer_size` (no work to do);
+  /// - the new pointer space is too small to address the current
+  ///   `node_count` or `leaf_count`;
+  /// - the new pointer size would change `leaf_size` (Map padding case,
+  ///   i.e. `new_pointer_size > leaf_size`);
+  /// - growing while the empty-leaves free list is non-empty (the
+  ///   chain links inside leaves would need re-encoding; not currently
+  ///   handled).
+  ///
+  /// On success, the region is grown if needed (for the growing case)
+  /// and a `ResizeState` is returned. No nodes have been migrated yet.
+  public func beginResize(self : StableTrie, new_pointer_size : Nat) : ?ResizeState {
+    let valid = switch (new_pointer_size) {
+      case (1 or 2 or 4 or 5 or 6 or 8) true;
+      case _ false;
+    };
+    if (not valid) return null;
+    if (new_pointer_size == self.pointer_size) return null;
+
+    let new_pointer_size_ = Prim.intToNat64Wrap(new_pointer_size);
+    let new_max_address : Nat64 = 2 ** (new_pointer_size_ * 8 - 1);
+
+    if (self.node_count > new_max_address) return null;
+    if (self.leaf_count > new_max_address) return null;
+
+    // Refuse if leaf_size would change (Map padding case).
+    if (new_pointer_size_ > self.leaf_size) return null;
+
+    let shrinking = new_pointer_size < self.pointer_size;
+
+    // Growing with a non-empty leaves free list would require rewriting
+    // the chain links inside freed leaves; not handled here.
+    if (not shrinking and self.empty_leaves_list.count > 0) return null;
+
+    let new_node_size = self.aridity_ *% new_pointer_size_;
+    let new_root_size = self.root_aridity_ *% new_pointer_size_;
+    let new_offset_base = new_root_size -% new_node_size;
+    let new_padding = 8 -% new_pointer_size_;
+    let new_loadMask : Nat64 = if (new_pointer_size == 8) 0xffff_ffff_ffff_ffff else (1 << (new_pointer_size_ << 3)) -% 1;
+    let new_safe_node_bound : Nat64 = if (self.max_chain_depth >= new_max_address) 0 else new_max_address -% self.max_chain_depth;
+
+    let region = self.nodes_region;
+
+    // Grow region if needed (only relevant for the growing direction).
+    let new_used = new_root_size +% (self.node_count -% 1) *% new_node_size +% new_padding;
+    let region_bytes = region.size() *% 65536;
+    if (region_bytes < new_used) {
+      let extra_needed = new_used -% region_bytes;
+      let extra_pages = (extra_needed +% 65535) / 65536;
+      assert region.grow(extra_pages) != 0xffff_ffff_ffff_ffff;
+    };
+    let final_region_bytes = region.size() *% 65536;
+    let new_nodes_freeSpace = final_region_bytes -% new_used;
+
+    ?{
+      nodes_region = self.nodes_region;
+      leaves_region = self.leaves_region;
+      node_count = self.node_count;
+      leaf_count = self.leaf_count;
+      old_pointer_size = self.pointer_size;
+      old_pointer_size_ = self.pointer_size_;
+      old_node_size = self.node_size;
+      old_offset_base = self.offset_base;
+      old_loadMask = self.loadMask;
+      new_pointer_size;
+      new_pointer_size_;
+      new_node_size;
+      new_root_size;
+      new_offset_base;
+      new_loadMask;
+      new_max_address;
+      new_safe_node_bound;
+      new_padding;
+      new_nodes_freeSpace;
+      key_size = self.key_size;
+      value_size = self.value_size;
+      aridity_ = self.aridity_;
+      key_size_ = self.key_size_;
+      root_aridity_ = self.root_aridity_;
+      bitlength = self.bitlength;
+      bitshift = self.bitshift;
+      max_chain_depth = self.max_chain_depth;
+      root_bitlength_ = self.root_bitlength_;
+      root_bitlength = self.root_bitlength;
+      leaf_size = self.leaf_size;
+      empty_values = self.empty_values;
+      empty_nodes_count = self.empty_nodes_list.count;
+      // The free-list "empty" sentinel is `last_empty_item == loadMask`, and
+      // loadMask depends on pointer_size. A list that's empty under the old
+      // layout has its head set to the OLD loadMask. After the resize the
+      // new list will compare against the NEW loadMask, so we translate the
+      // sentinel here. Real (in-range) indices are preserved verbatim — they
+      // already fit in the new pointer width (we checked node_count and
+      // leaf_count above).
+      empty_nodes_last = if (self.empty_nodes_list.last_empty_item == self.loadMask) new_loadMask else self.empty_nodes_list.last_empty_item;
+      empty_leaves_count = self.empty_leaves_list.count;
+      empty_leaves_last = if (self.empty_leaves_list.last_empty_item == self.loadMask) new_loadMask else self.empty_leaves_list.last_empty_item;
+      leaves_freeSpace = self.leaves_freeSpace;
+      shrinking;
+      var processed = 0 : Nat64;
+    };
+  };
+
+  /// Migrate up to `batch_size` nodes. Returns `true` when every node has
+  /// been migrated (after which `completeResize` should be called).
+  /// Calling again after returning `true` is a no-op that still returns
+  /// `true`.
+  public func stepResize(state : ResizeState, batch_size : Nat) : Bool {
+    let region = state.nodes_region;
+    let aridity_ = state.aridity_;
+    let root_aridity_ = state.root_aridity_;
+    let node_count = state.node_count;
+    let batch64 = Prim.intToNat64Wrap(batch_size);
+
+    var processed = state.processed;
+    let remaining = node_count -% processed;
+    var to_process = if (remaining < batch64) remaining else batch64;
+
+    if (state.shrinking) {
+      while (to_process > 0) {
+        let node_idx = processed;
+        let n_slots = if (node_idx == 0) root_aridity_ else aridity_;
+        let old_pos = if (node_idx == 0) 0 : Nat64 else state.old_offset_base +% node_idx *% state.old_node_size;
+        let new_pos = if (node_idx == 0) 0 : Nat64 else state.new_offset_base +% node_idx *% state.new_node_size;
+
+        var slot : Nat64 = 0;
+        while (slot < n_slots) {
+          let old_slot_offset = old_pos +% slot *% state.old_pointer_size_;
+          let value = Prim.regionLoadNat64(region, old_slot_offset) & state.old_loadMask;
+          let new_slot_offset = new_pos +% slot *% state.new_pointer_size_;
+          writePointerN(region, state.new_pointer_size, new_slot_offset, value);
+          slot +%= 1;
+        };
+
+        processed +%= 1;
+        to_process -%= 1;
+      };
+    } else {
+      while (to_process > 0) {
+        let node_idx = node_count -% 1 -% processed;
+        let n_slots = if (node_idx == 0) root_aridity_ else aridity_;
+        let old_pos = if (node_idx == 0) 0 : Nat64 else state.old_offset_base +% node_idx *% state.old_node_size;
+        let new_pos = if (node_idx == 0) 0 : Nat64 else state.new_offset_base +% node_idx *% state.new_node_size;
+
+        // Slots walked right-to-left so that writes at higher slots
+        // don't clobber the actual byte range of lower slots before we
+        // read them.
+        var slot : Nat64 = n_slots;
+        while (slot > 0) {
+          slot -%= 1;
+          let old_slot_offset = old_pos +% slot *% state.old_pointer_size_;
+          let value = Prim.regionLoadNat64(region, old_slot_offset) & state.old_loadMask;
+          let new_slot_offset = new_pos +% slot *% state.new_pointer_size_;
+          writePointerN(region, state.new_pointer_size, new_slot_offset, value);
+        };
+
+        processed +%= 1;
+        to_process -%= 1;
+      };
+    };
+
+    state.processed := processed;
+    processed == node_count;
+  };
+
+  /// Assemble the new `StableTrie` from a completed resize. Traps if
+  /// `stepResize` has not yet returned `true`. The returned trie shares
+  /// the (now-rewritten) regions with the original; the caller must
+  /// stop using the original reference.
+  public func completeResize(state : ResizeState) : StableTrie {
+    assert state.processed == state.node_count;
+
+    {
+      pointer_size = state.new_pointer_size;
+      key_size = state.key_size;
+      value_size = state.value_size;
+      aridity_ = state.aridity_;
+      key_size_ = state.key_size_;
+      pointer_size_ = state.new_pointer_size_;
+      root_aridity_ = state.root_aridity_;
+      loadMask = state.new_loadMask;
+      bitlength = state.bitlength;
+      bitshift = state.bitshift;
+      max_address = state.new_max_address;
+      max_chain_depth = state.max_chain_depth;
+      safe_node_bound = state.new_safe_node_bound;
+      root_bitlength_ = state.root_bitlength_;
+      root_bitlength = state.root_bitlength;
+      node_size = state.new_node_size;
+      node_size_ = nat64toNat(state.new_node_size);
+      leaf_size = state.leaf_size;
+      root_size = state.new_root_size;
+      offset_base = state.new_offset_base;
+      padding = state.new_padding;
+      empty_values = state.empty_values;
+      empty_nodes_list = {
+        offset_base = state.new_offset_base;
+        item_size = state.new_node_size;
+        pointer_size = state.new_pointer_size;
+        loadMask = state.new_loadMask;
+        var count = state.empty_nodes_count;
+        var last_empty_item = state.empty_nodes_last;
+      };
+      empty_leaves_list = {
+        offset_base = 0 : Nat64;
+        item_size = state.leaf_size;
+        pointer_size = state.new_pointer_size;
+        loadMask = state.new_loadMask;
+        var count = state.empty_leaves_count;
+        var last_empty_item = state.empty_leaves_last;
+      };
+      var leaf_count = state.leaf_count;
+      var node_count = state.node_count;
+      var nodes_region = state.nodes_region;
+      var nodes_freeSpace = state.new_nodes_freeSpace;
+      var leaves_region = state.leaves_region;
+      var leaves_freeSpace = state.leaves_freeSpace;
+    };
+  };
+
+  /// Write `value` at `offset` using exactly `ps` bytes (low-endian).
+  /// Mirrors `Layout.setChild`'s dispatch table but parameterised by an
+  /// arbitrary pointer width, so it can write the *new* width into a
+  /// region still otherwise indexed by the old width.
+  func writePointerN(region : Region.Region, ps : Nat, offset : Nat64, value : Nat64) {
+    if (ps == 2) {
+      region.storeNat16(offset, nat32to16(nat64to32(value)));
+    } else if (ps == 4) {
+      region.storeNat32(offset, nat64to32(value));
+    } else if (ps == 5) {
+      region.storeNat32(offset, nat64to32(value & 0xffff_ffff));
+      region.storeNat8(offset +% 4, natWrap8(nat64toNat(value >> 32)));
+    } else if (ps == 6) {
+      region.storeNat32(offset, nat64to32(value & 0xffff_ffff));
+      region.storeNat16(offset +% 4, nat32to16(nat64to32(value >> 32)));
+    } else if (ps == 8) {
+      region.storeNat64(offset, value);
+    } else {
+      // ps == 1
+      region.storeNat8(offset, natWrap8(nat64toNat(value)));
     };
   };
 };

--- a/test/resize.test.mo
+++ b/test/resize.test.mo
@@ -6,9 +6,15 @@
 import Blob "mo:core/Blob";
 import Iter "mo:core/Iter";
 import Nat8 "mo:core/Nat8";
+import Nat64 "mo:core/Nat64";
 import Nat_ "mo:core/Nat";
+import _Region "mo:core/Region"; // dot-notation on `nodes_region`/`leaves_region`
 
 import Map "../src/Map";
+// Enumeration is intentionally NOT imported in this file — it would make
+// every dot-notation call on a Map value ambiguous (Map and Enumeration
+// share signatures for `size`, `add`, `get`, etc.). Enumeration's resize
+// is exercised in resize_enum.test.mo.
 
 func keyOf(i : Nat) : Blob = Blob.fromArray([
   Nat8.fromNat(i % 256),
@@ -145,3 +151,181 @@ assert refused(m.beginResize(4)); // no-op (same pointer_size)
 assert refused(m.beginResize(3)); // invalid
 assert refused(m.beginResize(7)); // invalid
 assert refused(m.beginResize(0)); // invalid
+
+// ─── Edge size: empty trie ────────────────────────────────────────────────
+
+do {
+  let em = Map.empty({
+    pointer_size = 1;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 1;
+    value_size = 1;
+  });
+  assert em.size() == 0;
+
+  // Round-trip an empty trie. node_count is just 1 (the root), so the
+  // resize processes a single node.
+  var em_now : Map.Map = em;
+  em_now := resize(em_now, 2, 100);
+  assert em_now.size() == 0;
+  em_now := resize(em_now, 1, 100);
+  assert em_now.size() == 0;
+
+  // Functional afterwards.
+  em_now.add("\01", "x");
+  assert em_now.get("\01") == ?("x" : Blob);
+};
+
+// ─── Edge size: single entry ──────────────────────────────────────────────
+
+do {
+  let sm = Map.empty({
+    pointer_size = 1;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 1;
+    value_size = 1;
+  });
+  sm.add("\05", "y");
+  assert sm.size() == 1;
+
+  var sm_now : Map.Map = sm;
+  sm_now := resize(sm_now, 2, 100);
+  assert sm_now.size() == 1;
+  assert sm_now.get("\05") == ?("y" : Blob);
+};
+
+// ─── batch_size = 1 (forces one node per call) ────────────────────────────
+
+do {
+  let bm = Map.empty({
+    pointer_size = 1;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 1;
+    value_size = 1;
+  });
+  for (i in Nat_.range(0, 30)) {
+    bm.add(Blob.fromArray([Nat8.fromNat(i)]), Blob.fromArray([Nat8.fromNat(i)]));
+  };
+
+  var bm_now : Map.Map = bm;
+  bm_now := resize(bm_now, 2, 1); // one node per stepResize call
+  assert bm_now.size() == 30;
+  for (i in Nat_.range(0, 30)) {
+    assert bm_now.get(Blob.fromArray([Nat8.fromNat(i)])) == ?Blob.fromArray([Nat8.fromNat(i)]);
+  };
+};
+
+// ─── batch_size >> node_count (one call finishes) ─────────────────────────
+
+do {
+  let lm = Map.empty({
+    pointer_size = 1;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 1;
+    value_size = 1;
+  });
+  for (i in Nat_.range(0, 10)) {
+    lm.add(Blob.fromArray([Nat8.fromNat(i)]), Blob.fromArray([Nat8.fromNat(i)]));
+  };
+
+  // Single stepResize call with batch huge → done in one call.
+  var lm_now : Map.Map = lm;
+  let state = switch (lm_now.beginResize(2)) {
+    case (?s) s;
+    case null { assert false; loop {} };
+  };
+  let done = Map.stepResize(state, 10_000);
+  assert done;
+  lm_now := Map.completeResize(state);
+  assert lm_now.size() == 10;
+};
+
+// ─── leaf_size refusal ────────────────────────────────────────────────────
+//
+// Map with key_size + value_size = 1, pointer_size = 1. leaf_size = 1.
+// Growing to a pointer_size larger than leaf_size would make future
+// `pushEmptyLeaf` writes overflow the leaf — refused.
+
+do {
+  let lm = Map.empty({
+    pointer_size = 1;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 1;
+    value_size = 0;
+  });
+  lm.add("\01", "");
+  // leaf_size is max(1, 1) = 1; growing to any larger ps would refuse.
+  assert refused(lm.beginResize(2));
+  assert refused(lm.beginResize(4));
+  assert refused(lm.beginResize(8));
+};
+
+// ─── Capacity exceeded refusal ────────────────────────────────────────────
+
+do {
+  let cm = Map.empty({
+    pointer_size = 2;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 2;
+    value_size = 0;
+  });
+  for (i in Nat_.range(0, 200)) {
+    cm.add(Blob.fromArray([Nat8.fromNat(i % 256), Nat8.fromNat(i / 256)]), "");
+  };
+  // ps=1 caps leaf_count at 128. 200 > 128 → refuse.
+  assert refused(cm.beginResize(1));
+};
+
+// ─── Round-trip byte-identity ─────────────────────────────────────────────
+//
+// After `n → m → n` (with deletes in the mix to populate both free lists)
+// and no intervening writes, the used portion of both regions should be
+// byte-identical to the pre-resize snapshot. Strong correctness invariant —
+// any subtle off-by-one in offset arithmetic during the rewrite would
+// surface here.
+
+do {
+  let rm = Map.empty({
+    pointer_size = 2;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 4;
+    value_size = 4;
+  });
+  for (i in Nat_.range(0, 30)) {
+    rm.add(keyOf(i), valueOf(i));
+  };
+  // Delete a few entries to populate both free lists (chain-link node + freed leaf).
+  assert rm.delete(keyOf(5));
+  assert rm.delete(keyOf(15));
+  assert rm.delete(keyOf(25));
+
+  // Snapshot the used portion of both regions.
+  let nodes_used : Nat = Nat64.toNat(rm.root_size +% (rm.node_count -% 1) *% rm.node_size);
+  let leaves_used : Nat = Nat64.toNat(rm.leaf_count *% rm.leaf_size);
+  let nodes_before = rm.nodes_region.loadBlob(0, nodes_used);
+  let leaves_before = rm.leaves_region.loadBlob(0, leaves_used);
+
+  // Round-trip 2 → 4 → 2.
+  var rm_now : Map.Map = rm;
+  rm_now := resize(rm_now, 4, 100);
+  rm_now := resize(rm_now, 2, 100);
+
+  // Used portion sizes match.
+  let nodes_used_after : Nat = Nat64.toNat(rm_now.root_size +% (rm_now.node_count -% 1) *% rm_now.node_size);
+  let leaves_used_after : Nat = Nat64.toNat(rm_now.leaf_count *% rm_now.leaf_size);
+  assert nodes_used == nodes_used_after;
+  assert leaves_used == leaves_used_after;
+
+  // Byte-identical.
+  let nodes_after = rm_now.nodes_region.loadBlob(0, nodes_used);
+  let leaves_after = rm_now.leaves_region.loadBlob(0, leaves_used);
+  assert nodes_before == nodes_after;
+  assert leaves_before == leaves_after;
+};

--- a/test/resize.test.mo
+++ b/test/resize.test.mo
@@ -90,6 +90,49 @@ do {
   assert entries.size() == N + 2;
 };
 
+// ─── Grow with a non-empty empty_leaves_list ──────────────────────────────
+//
+// Delete some keys without re-adding so that the leaves free list carries
+// real entries across the next resize. Then shrink to 2, then grow back
+// to 4. After both migrations, the freed slots should still be on the
+// list and get reused by subsequent adds.
+
+assert m.delete(keyOf(5));
+assert m.delete(keyOf(7));
+assert m.delete(keyOf(9));
+let after_deletes_size = m.size();
+
+// Shrink with non-empty leaves list.
+m := resize(m, 2, 13);
+assert m.size() == after_deletes_size;
+assert m.get(keyOf(5)) == null;
+assert m.get(keyOf(7)) == null;
+assert m.get(keyOf(9)) == null;
+// Still readable for everything else.
+assert m.get(keyOf(0)) == ?valueOf(0);
+assert m.get(keyOf(N + 1)) == ?valueOf(N + 1);
+
+// Grow back to 4 with the leaves free list still non-empty.
+m := resize(m, 4, 5);
+assert m.size() == after_deletes_size;
+assert m.get(keyOf(5)) == null;
+assert m.get(keyOf(7)) == null;
+assert m.get(keyOf(9)) == null;
+assert m.get(keyOf(0)) == ?valueOf(0);
+assert m.get(keyOf(N + 1)) == ?valueOf(N + 1);
+
+// Adding three new keys should reuse the three freed slots via the
+// surviving leaves free list (no new high-water leaf allocations needed).
+let leaf_count_before = m.leaf_count;
+m.add(keyOf(N + 2), valueOf(N + 2));
+m.add(keyOf(N + 3), valueOf(N + 3));
+m.add(keyOf(N + 4), valueOf(N + 4));
+assert m.leaf_count == leaf_count_before; // free-list reuse, no new allocation
+assert m.size() == after_deletes_size + 3;
+assert m.get(keyOf(N + 2)) == ?valueOf(N + 2);
+assert m.get(keyOf(N + 3)) == ?valueOf(N + 3);
+assert m.get(keyOf(N + 4)) == ?valueOf(N + 4);
+
 // ─── Refusal cases ─────────────────────────────────────────────────────────
 
 // Helper — `?Map.ResizeState` isn't `==`-comparable (record has a `var`).

--- a/test/resize.test.mo
+++ b/test/resize.test.mo
@@ -1,0 +1,104 @@
+// @testmode wasi
+//
+// Incremental pointer-size resize: shrink 4 → 2, grow back 2 → 4. Verify
+// all entries readable after each migration.
+
+import Blob "mo:core/Blob";
+import Iter "mo:core/Iter";
+import Nat8 "mo:core/Nat8";
+import Nat_ "mo:core/Nat";
+
+import Map "../src/Map";
+
+func keyOf(i : Nat) : Blob = Blob.fromArray([
+  Nat8.fromNat(i % 256),
+  Nat8.fromNat((i / 256) % 256),
+  Nat8.fromNat((i / 65536) % 256),
+  Nat8.fromNat((i / 16777216) % 256),
+]);
+
+func valueOf(i : Nat) : Blob = Blob.fromArray([
+  Nat8.fromNat(i % 256),
+  Nat8.fromNat((i / 256) % 256),
+  Nat8.fromNat((i / 65536) % 256),
+  Nat8.fromNat((i / 16777216) % 256),
+]);
+
+// Drive an incremental resize to completion with a given batch size, so we
+// exercise stepResize being called multiple times.
+func resize(m : Map.Map, new_ps : Nat, batch : Nat) : Map.Map {
+  let state = switch (m.beginResize(new_ps)) {
+    case (?s) s;
+    case null { assert false; loop {} };
+  };
+  var done = false;
+  while (not done) {
+    done := Map.stepResize(state, batch);
+  };
+  Map.completeResize(state);
+};
+
+// ─── Round-trip: pointer_size = 4 → 2 → 4 ────────────────────────────────
+
+var m : Map.Map = Map.empty({
+  pointer_size = 4;
+  aridity = 4;
+  root_aridity = null;
+  key_size = 4;
+  value_size = 4;
+});
+
+let N = 200;
+for (i in Nat_.range(0, N)) {
+  m.add(keyOf(i), valueOf(i));
+};
+assert m.size() == N;
+
+// Shrink to pointer_size = 2 in batches of 7 (forces multiple stepResize calls).
+m := resize(m, 2, 7);
+
+assert m.size() == N;
+for (i in Nat_.range(0, N)) {
+  assert m.get(keyOf(i)) == ?valueOf(i);
+};
+
+// New writes after shrink.
+m.add(keyOf(N), valueOf(N));
+assert m.size() == N + 1;
+assert m.get(keyOf(N)) == ?valueOf(N);
+
+// Deletes work after shrink (exercises empty_nodes_list + new layout).
+assert m.delete(keyOf(0));
+assert m.get(keyOf(0)) == null;
+m.add(keyOf(0), valueOf(0));
+
+// Grow back to pointer_size = 4 in batches of 11.
+m := resize(m, 4, 11);
+
+assert m.size() == N + 1;
+for (i in Nat_.range(0, N + 1)) {
+  assert m.get(keyOf(i)) == ?valueOf(i);
+};
+
+m.add(keyOf(N + 1), valueOf(N + 1));
+assert m.size() == N + 2;
+assert m.get(keyOf(N + 1)) == ?valueOf(N + 1);
+
+// Iteration still yields N+2 entries.
+do {
+  let entries = Iter.toArray(m.entries());
+  assert entries.size() == N + 2;
+};
+
+// ─── Refusal cases ─────────────────────────────────────────────────────────
+
+// Helper — `?Map.ResizeState` isn't `==`-comparable (record has a `var`).
+func refused(s : ?Map.ResizeState) : Bool = switch s {
+  case null true;
+  case _ false;
+};
+
+assert refused(m.beginResize(4)); // no-op (same pointer_size)
+assert refused(m.beginResize(3)); // invalid
+assert refused(m.beginResize(7)); // invalid
+assert refused(m.beginResize(0)); // invalid

--- a/test/resize_enum.test.mo
+++ b/test/resize_enum.test.mo
@@ -1,0 +1,87 @@
+// @testmode wasi
+//
+// Incremental pointer-size resize for Enumeration.
+//
+// Enumeration differs from Map for the resize in two ways worth covering:
+//
+// - leaf_size = key_size + value_size (no Map-style padding).
+// - removal goes through `removeLast` → leaf_count decrements directly
+//   AND any collapsed internal nodes are pushed onto `empty_nodes_list`.
+//   The leaves free list is never populated.
+
+import Blob "mo:core/Blob";
+import Nat8 "mo:core/Nat8";
+import Nat_ "mo:core/Nat";
+
+import Enumeration "../src/Enumeration";
+
+let e = Enumeration.empty({
+  pointer_size = 1;
+  aridity = 4;
+  root_aridity = null;
+  key_size = 1;
+  value_size = 1;
+});
+
+// Add 20 entries (well within ps=1's 128-leaf cap).
+for (i in Nat_.range(0, 20)) {
+  ignore e.add(Blob.fromArray([Nat8.fromNat(i)]), Blob.fromArray([Nat8.fromNat(i)]));
+};
+
+// removeLast a few times to populate empty_nodes_list (Enumeration's only
+// free list — leaves are retracted via leaf_count, not pushed).
+ignore e.removeLast();
+ignore e.removeLast();
+ignore e.removeLast();
+assert e.size() == 17;
+let stats_before = e.memoryStats();
+
+// Grow 1 → 2.
+var e_now : Enumeration.Enumeration = e;
+do {
+  let state = switch (e_now.beginResize(2)) {
+    case (?s) s;
+    case null { assert false; loop {} };
+  };
+  while (not Enumeration.stepResize(state, 4)) {};
+  e_now := Enumeration.completeResize(state);
+};
+assert e_now.size() == 17;
+for (i in Nat_.range(0, 17)) {
+  assert e_now.lookup(Blob.fromArray([Nat8.fromNat(i)])) == ?(Blob.fromArray([Nat8.fromNat(i)]), i);
+};
+// Node free list survived the migration.
+assert e_now.memoryStats().used_node_count == stats_before.used_node_count;
+
+// Shrink 2 → 1.
+do {
+  let state = switch (e_now.beginResize(1)) {
+    case (?s) s;
+    case null { assert false; loop {} };
+  };
+  while (not Enumeration.stepResize(state, 4)) {};
+  e_now := Enumeration.completeResize(state);
+};
+assert e_now.size() == 17;
+for (i in Nat_.range(0, 17)) {
+  assert e_now.lookup(Blob.fromArray([Nat8.fromNat(i)])) == ?(Blob.fromArray([Nat8.fromNat(i)]), i);
+};
+
+// New adds after the round-trip work, and the previously-freed internal
+// nodes can be re-used.
+ignore e_now.add(Blob.fromArray([Nat8.fromNat(50)]), Blob.fromArray([0]));
+ignore e_now.add(Blob.fromArray([Nat8.fromNat(51)]), Blob.fromArray([0]));
+assert e_now.size() == 19;
+
+// ─── Refusal cases ─────────────────────────────────────────────────────────
+
+func refused(s : ?Enumeration.ResizeState) : Bool = switch s {
+  case null true;
+  case _ false;
+};
+
+// Same-pointer-size: no-op refusal.
+assert refused(e_now.beginResize(1));
+// Invalid widths.
+assert refused(e_now.beginResize(3));
+assert refused(e_now.beginResize(0));


### PR DESCRIPTION
- Add ability to perform one-time pointer-size resizing
- **Breaking**: Internal representation is not compatible with 0.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.1.2

* **New Features**
  * Introduced incremental pointer-size resizing for `Map` and `Enumeration` structures via new `beginResize`, `stepResize`, and `completeResize` APIs, enabling multi-message migrations while sharing underlying storage.

* **Chores**
  * Updated Motoko toolchain requirement to 1.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->