### PR TITLE
feat: 0.1.1 → 0.1.2 migration function

### DIFF
--- a/src/Enumeration.mo
+++ b/src/Enumeration.mo
@@ -376,4 +376,21 @@ module {
   /// shares the now-rewritten regions with the original; the caller must
   /// stop using the original reference.
   public let completeResize : (state : ResizeState) -> Enumeration = Trie.completeResize;
+
+  // ─── Migration: 0.1.1 → 0.1.2 ─────────────────────────────────────────────
+
+  /// Stable-type shape of `Enumeration` as it appeared in stable-trie 0.1.1.
+  /// Use as the input type for `migrate_0_1_1`.
+  public type Enumeration_0_1_1 = Trie.StableTrie_0_1_1;
+
+  /// `migrate_0_1_1(old : Enumeration_0_1_1) : Enumeration`
+  ///
+  /// One-shot migration of an Enumeration persisted under stable-trie 0.1.1
+  /// to the 0.1.2 shape. Adds the new `zero_leaf` field. The empty-leaves
+  /// free list is always empty for Enumeration (removeLast decrements the
+  /// counter directly), so the migration walk is a no-op for Enumeration —
+  /// only the field attachment matters. The returned Enumeration shares
+  /// the original's regions; the original reference must not be used after
+  /// this call.
+  public let migrate_0_1_1 : (old : Enumeration_0_1_1) -> Enumeration = Trie.migrate_0_1_1;
 };

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -397,4 +397,20 @@ module {
   /// regions with the original; the caller must stop using the original
   /// reference (typically by holding the Map in a `var` and reassigning).
   public let completeResize : (state : ResizeState) -> Map = Trie.completeResize;
+
+  // ─── Migration: 0.1.1 → 0.1.2 ─────────────────────────────────────────────
+
+  /// Stable-type shape of `Map` as it appeared in stable-trie 0.1.1. Use as
+  /// the input type for `migrate_0_1_1`.
+  public type Map_0_1_1 = Trie.StableTrie_0_1_1;
+
+  /// `migrate_0_1_1(old : Map_0_1_1) : Map`
+  ///
+  /// One-shot migration of a Map persisted under stable-trie 0.1.1 to the
+  /// 0.1.2 shape. Adds the new `zero_leaf` field and, if the empty-leaves
+  /// free list is non-empty, brings each freed leaf into the 0.1.2
+  /// invariant (zeroed past the chain link). The returned Map shares the
+  /// original's regions and LinkedList instances; the original reference
+  /// must not be used after this call.
+  public let migrate_0_1_1 : (old : Map_0_1_1) -> Map = Trie.migrate_0_1_1;
 };

--- a/src/internal/trie.mo
+++ b/src/internal/trie.mo
@@ -889,4 +889,138 @@ module {
       region.storeNat8(offset, natWrap8(nat64toNat(value)));
     };
   };
+
+  // ─── Migration: 0.1.1 → 0.1.2 ──────────────────────────────────────────────
+  //
+  // 0.1.2 added one field to the `StableTrie` record (`zero_leaf : Blob`) and
+  // changed the LinkedList invariant: every item currently in the
+  // `empty_leaves_list` is expected to be all-zero past its chain link, with
+  // the bottom item all-zero (no in-region sentinel). A persistent actor that
+  // upgrades from 0.1.1 to 0.1.2 has to (a) attach the new field and (b)
+  // bring any existing freed leaves into the new invariant. This function
+  // does both in one pass.
+
+  /// Stable-type shape of `StableTrie` as it appeared in stable-trie 0.1.1.
+  /// Identical to `StableTrie` except for the missing `zero_leaf : Blob`
+  /// field. Use this as the "old" type for the 0.1.1 → 0.1.2 migration.
+  public type StableTrie_0_1_1 = {
+    pointer_size : Nat;
+    key_size : Nat;
+    value_size : Nat;
+    aridity_ : Nat64;
+    key_size_ : Nat64;
+    pointer_size_ : Nat64;
+    root_aridity_ : Nat64;
+    loadMask : Nat64;
+    bitlength : Nat16;
+    bitshift : Nat8;
+    max_address : Nat64;
+    max_chain_depth : Nat64;
+    safe_node_bound : Nat64;
+    root_bitlength_ : Nat64;
+    root_bitlength : Nat16;
+    node_size : Nat64;
+    node_size_ : Nat;
+    leaf_size : Nat64;
+    root_size : Nat64;
+    offset_base : Nat64;
+    padding : Nat64;
+    empty_values : Bool;
+    empty_nodes_list : LinkedList.LinkedList;
+    empty_leaves_list : LinkedList.LinkedList;
+    var leaf_count : Nat64;
+    var node_count : Nat64;
+    var nodes_region : Region.Region;
+    var nodes_freeSpace : Nat64;
+    var leaves_region : Region.Region;
+    var leaves_freeSpace : Nat64;
+  };
+
+  /// One-shot migration from a 0.1.1-shaped `StableTrie` to the 0.1.2 shape.
+  /// Two things happen:
+  ///
+  /// 1. The new `zero_leaf : Blob` field is computed and attached.
+  /// 2. If the empty-leaves free list is non-empty, it is walked once and
+  ///    each freed leaf is brought into the new invariant — every byte past
+  ///    the chain link is zeroed, and the bottom item's chain-link slot
+  ///    (which 0.1.1 set to the in-region `loadMask` sentinel) is also
+  ///    zeroed since 0.1.2's `pop` never reads it and the new invariant
+  ///    expects an all-zero bottom.
+  ///
+  /// The returned trie shares the original's regions and LinkedList
+  /// instances. After this call, the original reference must NOT be used.
+  ///
+  /// Empty-nodes free list: not touched. 0.1.1 already cleared every slot
+  /// of a node before pushing it (via `Map.removeRec`'s
+  /// `setChild(node, slot, 0)`), so freed nodes already satisfy the
+  /// 0.1.2 invariant.
+  public func migrate_0_1_1(old : StableTrie_0_1_1) : StableTrie {
+    let zero_leaf = Blob.fromArray(Array.tabulate<Nat8>(nat64toNat(old.leaf_size), func(_) = 0));
+
+    // Bring the empty_leaves_list contents into the new "items are all-zero
+    // past the chain link" invariant. Only matters for Map (Enumeration
+    // never pushes to this list).
+    if (old.empty_leaves_list.count > 0) {
+      let leaves_region = old.leaves_region;
+      let ps_ = old.pointer_size_;
+      let leaf_size = old.leaf_size;
+      let mask = old.loadMask;
+      let tail_len_nat = nat64toNat(leaf_size -% ps_);
+      let zero_tail = Blob.fromArray(Array.tabulate<Nat8>(tail_len_nat, func(_) = 0));
+
+      var current = old.empty_leaves_list.last_empty_item;
+      var remaining = old.empty_leaves_list.count;
+      while (remaining > 0) {
+        let slot_offset = current *% leaf_size;
+        if (remaining == 1) {
+          // Bottom — overwrite the whole slot with zeros (chain link
+          // included; was loadMask under 0.1.1).
+          leaves_region.storeBlob(slot_offset, zero_leaf);
+        } else {
+          // Non-bottom — read the chain link to find the next item below,
+          // then zero only the tail bytes.
+          let next = leaves_region.loadNat64(slot_offset) & mask;
+          if (tail_len_nat > 0) {
+            leaves_region.storeBlob(slot_offset +% ps_, zero_tail);
+          };
+          current := next;
+        };
+        remaining -= 1;
+      };
+    };
+
+    {
+      pointer_size = old.pointer_size;
+      key_size = old.key_size;
+      value_size = old.value_size;
+      aridity_ = old.aridity_;
+      key_size_ = old.key_size_;
+      pointer_size_ = old.pointer_size_;
+      root_aridity_ = old.root_aridity_;
+      loadMask = old.loadMask;
+      bitlength = old.bitlength;
+      bitshift = old.bitshift;
+      max_address = old.max_address;
+      max_chain_depth = old.max_chain_depth;
+      safe_node_bound = old.safe_node_bound;
+      root_bitlength_ = old.root_bitlength_;
+      root_bitlength = old.root_bitlength;
+      node_size = old.node_size;
+      node_size_ = old.node_size_;
+      leaf_size = old.leaf_size;
+      root_size = old.root_size;
+      offset_base = old.offset_base;
+      padding = old.padding;
+      empty_values = old.empty_values;
+      zero_leaf;
+      empty_nodes_list = old.empty_nodes_list;
+      empty_leaves_list = old.empty_leaves_list;
+      var leaf_count = old.leaf_count;
+      var node_count = old.node_count;
+      var nodes_region = old.nodes_region;
+      var nodes_freeSpace = old.nodes_freeSpace;
+      var leaves_region = old.leaves_region;
+      var leaves_freeSpace = old.leaves_freeSpace;
+    };
+  };
 };

--- a/test/migrate.test.mo
+++ b/test/migrate.test.mo
@@ -1,0 +1,157 @@
+// @testmode wasi
+//
+// Migration from stable-trie 0.1.1 → 0.1.2.
+//
+// Two things change between 0.1.1 and 0.1.2 from a persisted-state
+// perspective:
+//
+// 1. `StableTrie` grew a new field `zero_leaf : Blob`. A 0.1.1 record has
+//    no value for it, so a plain upgrade would fail.
+// 2. The LinkedList invariant changed: items currently in
+//    `empty_leaves_list` are now expected to be all-zero past their chain
+//    link. 0.1.1 only wrote the chain link, leaving the deleted leaf's
+//    key/value bytes as stale tail data.
+//
+// `Map.migrate_0_1_1` handles both — attaches `zero_leaf` and, if the
+// list is non-empty, walks it once to zero out the stale tail bytes.
+
+import Blob "mo:core/Blob";
+import Nat8 "mo:core/Nat8";
+import Nat_ "mo:core/Nat";
+import _Region "mo:core/Region"; // enables `region.storeBlob(...)` dot notation
+
+import Map "../src/Map";
+
+// Helper — view a real 0.1.2 Map as a 0.1.1-shaped record. Used in tests
+// to feed the migration a value that has all the 0.1.1 fields but lacks
+// `zero_leaf`. Regions and LinkedList instances are SHARED with the
+// original Map (no copy); the var fields are snapshotted (independent).
+func downgrade(m : Map.Map) : Map.Map_0_1_1 = {
+  pointer_size = m.pointer_size;
+  key_size = m.key_size;
+  value_size = m.value_size;
+  aridity_ = m.aridity_;
+  key_size_ = m.key_size_;
+  pointer_size_ = m.pointer_size_;
+  root_aridity_ = m.root_aridity_;
+  loadMask = m.loadMask;
+  bitlength = m.bitlength;
+  bitshift = m.bitshift;
+  max_address = m.max_address;
+  max_chain_depth = m.max_chain_depth;
+  safe_node_bound = m.safe_node_bound;
+  root_bitlength_ = m.root_bitlength_;
+  root_bitlength = m.root_bitlength;
+  node_size = m.node_size;
+  node_size_ = m.node_size_;
+  leaf_size = m.leaf_size;
+  root_size = m.root_size;
+  offset_base = m.offset_base;
+  padding = m.padding;
+  empty_values = m.empty_values;
+  empty_nodes_list = m.empty_nodes_list;
+  empty_leaves_list = m.empty_leaves_list;
+  var leaf_count = m.leaf_count;
+  var node_count = m.node_count;
+  var nodes_region = m.nodes_region;
+  var nodes_freeSpace = m.nodes_freeSpace;
+  var leaves_region = m.leaves_region;
+  var leaves_freeSpace = m.leaves_freeSpace;
+};
+
+func key4(i : Nat) : Blob = Blob.fromArray([Nat8.fromNat(i), 0, 0, 0]);
+
+// ─── Basic migration: empty free lists ────────────────────────────────────
+
+do {
+  let m = Map.empty({
+    pointer_size = 4;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 4;
+    value_size = 4;
+  });
+  for (i in Nat_.range(0, 20)) {
+    m.add(key4(i), key4(i));
+  };
+
+  let migrated = Map.migrate_0_1_1(downgrade(m));
+
+  // All 20 entries readable.
+  assert migrated.size() == 20;
+  for (i in Nat_.range(0, 20)) {
+    assert migrated.get(key4(i)) == ?key4(i);
+  };
+  // Add / delete still work.
+  migrated.add(key4(99), key4(99));
+  assert migrated.get(key4(99)) == ?key4(99);
+  assert migrated.delete(key4(0));
+  assert migrated.get(key4(0)) == null;
+};
+
+// ─── Migration with a non-empty empty_leaves_list ─────────────────────────
+
+do {
+  let m = Map.empty({
+    pointer_size = 4;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 4;
+    value_size = 4;
+  });
+  // leaf_size = max(4 + 4, 4) = 8; pointer_size = 4 → tail bytes = [4, 8).
+  for (i in Nat_.range(0, 20)) {
+    m.add(key4(i), key4(i));
+  };
+  assert m.delete(key4(5));
+  assert m.delete(key4(7));
+  assert m.delete(key4(9));
+  let live = m.size();
+  assert live == 17;
+  assert m.empty_leaves_list.count == 3;
+
+  // Manually overwrite the head freed leaf's tail bytes to simulate the
+  // stale state that 0.1.1's push left behind. (0.1.2's `Map.removeRec`
+  // zeros the leaf before push, so the head currently has zeros there.)
+  let head_index = m.empty_leaves_list.last_empty_item;
+  let slot_offset : Nat64 = head_index * m.leaf_size;
+  let stale_tail = Blob.fromArray([
+    Nat8.fromNat(0xff),
+    Nat8.fromNat(0xee),
+    Nat8.fromNat(0xdd),
+    Nat8.fromNat(0xcc),
+  ]);
+  m.leaves_region.storeBlob(slot_offset + 4, stale_tail); // [4, 8)
+
+  // Snapshot the chain link before migration so we can prove it's preserved.
+  let chain_link_before = m.leaves_region.loadNat64(slot_offset) & m.loadMask;
+
+  let migrated = Map.migrate_0_1_1(downgrade(m));
+
+  // Chain link preserved.
+  let chain_link_after = migrated.leaves_region.loadNat64(slot_offset) & migrated.loadMask;
+  assert chain_link_before == chain_link_after;
+  // Tail bytes zeroed by the migration walk.
+  let tail = migrated.leaves_region.loadBlob(slot_offset + 4, 4);
+  assert tail == Blob.fromArray([0, 0, 0, 0] : [Nat8]);
+
+  // Functional checks: all 17 surviving entries still readable, deleted
+  // keys still gone.
+  assert migrated.size() == 17;
+  for (i in Nat_.range(0, 20)) {
+    if (i == 5 or i == 7 or i == 9) {
+      assert migrated.get(key4(i)) == null;
+    } else {
+      assert migrated.get(key4(i)) == ?key4(i);
+    };
+  };
+
+  // Adding three new keys reuses the freed slots from the migrated free
+  // list — leaf_count high-water unchanged.
+  let high_water = migrated.leaf_count;
+  migrated.add(key4(30), key4(30));
+  migrated.add(key4(31), key4(31));
+  migrated.add(key4(32), key4(32));
+  assert migrated.leaf_count == high_water;
+  assert migrated.size() == 20;
+};


### PR DESCRIPTION
Add Trie.migrate_0_1_1 (exposed on Map and Enumeration) for users upgrading from stable-trie 0.1.1 to 0.1.2.

Between 0.1.1 and 0.1.2 two things changed in the persisted layout:

1. StableTrie grew a `zero_leaf : Blob` field. A plain canister upgrade would fail because the 0.1.1 record has no value for it.
2. The LinkedList invariant changed — items currently in empty_leaves_list are now expected to be all-zero past their chain link. 0.1.1's `Map.removeRec` + `LinkedList.push` only wrote the chain link bytes, leaving the rest of the freed leaf as stale key/value data.

migrate_0_1_1 handles both:

- attaches the new zero_leaf (computed from leaf_size);
- if empty_leaves_list is non-empty, walks the chain once and zeros the tail bytes [pointer_size, leaf_size) of every freed leaf, plus the entire slot of the bottom item (which 0.1.1 set to its loadMask sentinel; 0.1.2 expects all-zero).

empty_nodes_list is not touched: 0.1.1 already cleared every slot of a collapsed node via `Layout.setChild(node, slot, 0)` before pushEmptyNode, so freed nodes already satisfy the 0.1.2 invariant.

The returned trie shares regions and LinkedList instances with the input; the original reference must not be used after the call.

src/internal/trie.mo
  - new type StableTrie_0_1_1 (same as StableTrie minus zero_leaf)
  - new func migrate_0_1_1(old : StableTrie_0_1_1) : StableTrie

src/Map.mo, src/Enumeration.mo
  - re-exports: type Map_0_1_1 / Enumeration_0_1_1 + migrate_0_1_1 public-let alias

test/migrate.test.mo
  - basic case: 20 entries, no deletes → migrate → verify lookups, add, delete still work.
  - tail-zeroing case: deletes that populate empty_leaves_list; the head freed leaf's tail bytes are manually overwritten with 0xFF sentinels (simulating 0.1.1's stale tail); migrate; verify chain link preserved, tail bytes now zero, surviving entries readable, freed slots reused by subsequent adds (leaf_count high-water unchanged).

Full 17-file suite passes; prettier clean.