### PR TITLE
Pointer size 3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Stable-trie changelog
 
-## Next
+## 0.1.3
 
+- Add support for `pointer_size = 3`
 - Add `nodes_region_pages` and `leaves_region_pages` fields to `MemoryStats`
 - Expose those plus `pointer_size` / `key_size` / `value_size` as Prometheus metrics in `toValue`
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ persistent actor {
 
 `beginResize` returns `null` (refuses to start) when:
 
-- `new_pointer_size` isn't one of `1, 2, 4, 5, 6, 8`;
+- `new_pointer_size` isn't one of `1, 2, 3, 4, 5, 6, 8`;
 - `new_pointer_size == self.pointer_size` (no migration to do);
 - the current `node_count` or `leaf_count` wouldn't fit in the new pointer space;
 - the migration would force `leaf_size` to change (Map padding case where `new_pointer_size > leaf_size`).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The other parameters are considered optimization parameters.
 
 - Pointer size. This is the byte size of the internal pointers stored in each node.  
   It can be set lower to save memory but that sets a limit on how large the trie can grow.
-  Allowed values are 2,4,5,6,8.
+  Allowed values are 2,3,4,5,6,8.
 
 ## Extensions
 
@@ -268,7 +268,7 @@ Iteration by key is the same set as `Map`'s (`entries`, `reverseEntries`, `keys`
 
 - **Fixed-width `Blob` keys and values.** `core/Map` and `core/List` are generic over their element type. Here every entry is `Blob → Blob` with the byte widths fixed at construction (`key_size`, `value_size`). Variable-width data can be stored indirectly — see the _Extensions_ section above.
 - **Stable-memory backed.** All data lives in `Region`s; the heap footprint is `O(1)` (region handles, counters, free-list heads). A `Map` or `Enumeration` value lives directly inside a `persistent actor` — no `share` / `unshare`.
-- **Bounded capacity.** The pointer size (`pointer_size = 2, 4, 5, 6, 8` bytes) caps how many entries the trie can hold. Writes can return `#err(#LimitExceeded)` via the `*Checked` variants; the trapping (`add`, `insert`, etc.) variants trap on overflow and rely on the IC's message rollback to undo any in-flight mutation. `core/Map` / `core/List` have no such limit.
+- **Bounded capacity.** The pointer size (`pointer_size = 2, 3, 4, 5, 6, 8` bytes) caps how many entries the trie can hold. Writes can return `#err(#LimitExceeded)` via the `*Checked` variants; the trapping (`add`, `insert`, etc.) variants trap on overflow and rely on the IC's message rollback to undo any in-flight mutation. `core/Map` / `core/List` have no such limit.
 - **No `swap` / `replace` on `Enumeration`.** With `lookup` (key → index) and `put` (index → value) both available, the user composes the two when they want swap/replace semantics — cheaper than re-walking the trie under the hood. So `Enumeration`'s key-write surface is intentionally narrower than `Map`'s.
 - **Iteration always sorted.** `Map.entries` and `Enumeration.entries` always iterate in ascending key order. `Enumeration` additionally exposes insertion-order traversal via `range` / `sliceToArray`.
 

--- a/example/mops.toml
+++ b/example/mops.toml
@@ -3,6 +3,8 @@ main = "src/main.mo"
 
 [dependencies]
 stable-trie = "../"
+# Replace with:
+# stable-trie = "0.1.3"
 promtracker = "1.0.1"
 core = "2.5.0"
 

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-trie"
-version = "0.1.2"
+version = "0.1.3"
 description = "Stable-memory trie-based key-value map"
 repository = "https://github.com/research-ag/stable-trie"
 keywords = [ "set", "enumeration", "lookup", "bijective", "key-value" ]

--- a/src/Enumeration.mo
+++ b/src/Enumeration.mo
@@ -92,7 +92,7 @@ module {
   /// Construct an empty `Enumeration`.
   ///
   /// Arguments:
-  /// + `pointer_size` — bytes for internal pointers (2, 4, 5, 6, 8).
+  /// + `pointer_size` — bytes for internal pointers (2, 3, 4, 5, 6, 8).
   /// + `aridity` — children per non-root internal node (2, 4, 16, 256).
   /// + `root_aridity` — children for the root node, or `null` to default
   ///   to `aridity`.

--- a/src/Map.mo
+++ b/src/Map.mo
@@ -66,7 +66,7 @@ module {
   ///
   /// Arguments:
   /// - `pointer_size : Nat` — bytes used for each internal pointer. One of
-  ///   `2, 4, 5, 6, 8`. Bounds the trie's capacity: at most `N/2` leaves
+  ///   `2, 3, 4, 5, 6, 8`. Bounds the trie's capacity: at most `N/2` leaves
   ///   and `N/2` internal nodes where `N = 256 ** pointer_size`.
   /// - `aridity : Nat` — number of children per non-root internal node.
   ///   One of `2, 4, 16, 256`. `4` is recommended for uniformly distributed

--- a/src/internal/layout.mo
+++ b/src/internal/layout.mo
@@ -6,7 +6,7 @@
 /// things live, and how to encode/decode them" — the algorithm itself
 /// (find/put/remove/lookup/iter) lives in `trie.mo`. `setChild`
 /// dispatches via an if-else cascade on `pointer_size` ordered
-/// `2 → 4 → 5 → 6 → 8` (most common first).
+/// `2 → 4 → 3 → 5 → 6 → 8` (most common first).
 ///
 /// The type definition lives here (rather than in `trie.mo`) to break the
 /// otherwise-circular dependency: `trie.mo`'s algorithm calls layout
@@ -118,7 +118,7 @@ module {
 
   /// Set node's `node` child number `index`.
   /// General version: nested if-else on `pointer_size`, checking sizes in
-  /// order 2, 4, 5, 6, 8, 1 (most common first; `ps = 1` is a test-only
+  /// order 2, 4, 3, 5, 6, 8, 1 (most common first; `ps = 1` is a test-only
   /// configuration and lives at the bottom of the cascade). Use this from
   /// sites where setChild is called only once. From hot sites that call it
   /// repeatedly (e.g. `put_`), hoist the dispatch by picking the matching
@@ -133,6 +133,9 @@ module {
       region.storeNat16(offset, nat32to16(nat64to32(child)));
     } else if (ps == 4) {
       region.storeNat32(offset, nat64to32(child));
+    } else if (ps == 3) {
+      region.storeNat16(offset, nat32to16(nat64to32(child & 0xffff)));
+      region.storeNat8(offset +% 2, natWrap8(nat64toNat(child >> 16)));
     } else if (ps == 5) {
       region.storeNat32(offset, nat64to32(child & 0xffff_ffff));
       region.storeNat8(offset +% 4, natWrap8(nat64toNat(child >> 32)));

--- a/src/internal/linked-list.mo
+++ b/src/internal/linked-list.mo
@@ -79,7 +79,7 @@ module {
   };
 
   /// Store a `pointer_size`-byte link at `offset`. Dispatches via if-else
-  /// on `ps`, ordered 2,4,5,6,8,1 — `pointer_size = 2` is by far the most
+  /// on `ps`, ordered 2,4,3,5,6,8,1 — `pointer_size = 2` is by far the most
   /// common case, so its branch is first; `ps = 1` is a test-only
   /// configuration at the bottom of the cascade.
   func storePointer(region : Region.Region, ps : Nat, offset : Nat64, link : Nat64) {
@@ -87,6 +87,9 @@ module {
       region.storeNat16(offset, nat32to16(nat64to32(link)));
     } else if (ps == 4) {
       region.storeNat32(offset, nat64to32(link));
+    } else if (ps == 3) {
+      region.storeNat16(offset, nat32to16(nat64to32(link & 0xffff)));
+      region.storeNat8(offset +% 2, natWrap8(nat64toNat(link >> 16)));
     } else if (ps == 5) {
       region.storeNat32(offset, nat64to32(link & 0xffff_ffff));
       region.storeNat8(offset +% 4, natWrap8(nat64toNat(link >> 32)));

--- a/src/internal/trie.mo
+++ b/src/internal/trie.mo
@@ -529,7 +529,10 @@ module {
   // Promtracker type Metric
   type Metric = (Text, Text, Nat);
 
-  // Promtracker type Value
+  /// Pull-style metrics source as expected by `mo:promtracker` (>= 1.0.1):
+  /// a record whose `read` function returns the current metrics as
+  /// `(name, labels, value)` tuples. Returned by `toValue` and meant to be
+  /// passed to promtracker's `renderer.addValue(...)`.
   public type Value = {
     read : () -> [Metric];
   };

--- a/src/internal/trie.mo
+++ b/src/internal/trie.mo
@@ -41,7 +41,7 @@ module {
   /// Constructor arguments shared by `Enumeration` and `Map`. The public
   /// `empty()` in those modules documents the fields in user-facing terms.
   ///
-  /// - `pointer_size : Nat` — pointer byte width; one of `2, 4, 5, 6, 8`.
+  /// - `pointer_size : Nat` — pointer byte width; one of `2, 3, 4, 5, 6, 8`.
   /// - `aridity : Nat` — children per non-root internal node; one of
   ///   `2, 4, 16, 256`.
   /// - `root_aridity : ?Nat` — children of the root node (must be a power
@@ -110,7 +110,7 @@ module {
       // 1 is intended for tests: it shrinks max_address to 2**7 = 128,
       // making it cheap to construct scenarios that hit the node/leaf
       // pointer cap. It is not meant to be used in production tries.
-      case (2 or 4 or 5 or 6 or 8 or 1) true;
+      case (2 or 3 or 4 or 5 or 6 or 8 or 1) true;
       case (_) false;
     };
     assert switch (args.aridity) {
@@ -656,7 +656,7 @@ module {
   /// Begin an incremental pointer-size migration. Returns `null` if the
   /// resize cannot proceed:
   ///
-  /// - `new_pointer_size` is not one of `1, 2, 4, 5, 6, 8`;
+  /// - `new_pointer_size` is not one of `1, 2, 3, 4, 5, 6, 8`;
   /// - `new_pointer_size == self.pointer_size` (no work to do);
   /// - the new pointer space is too small to address the current
   ///   `node_count` or `leaf_count`;
@@ -677,7 +677,7 @@ module {
   /// fits in the new pointer width.
   public func beginResize(self : StableTrie, new_pointer_size : Nat) : ?ResizeState {
     let valid = switch (new_pointer_size) {
-      case (1 or 2 or 4 or 5 or 6 or 8) true;
+      case (1 or 2 or 3 or 4 or 5 or 6 or 8) true;
       case _ false;
     };
     if (not valid) return null;
@@ -887,6 +887,9 @@ module {
       region.storeNat16(offset, nat32to16(nat64to32(value)));
     } else if (ps == 4) {
       region.storeNat32(offset, nat64to32(value));
+    } else if (ps == 3) {
+      region.storeNat16(offset, nat32to16(nat64to32(value & 0xffff)));
+      region.storeNat8(offset +% 2, natWrap8(nat64toNat(value >> 16)));
     } else if (ps == 5) {
       region.storeNat32(offset, nat64to32(value & 0xffff_ffff));
       region.storeNat8(offset +% 4, natWrap8(nat64toNat(value >> 32)));

--- a/test/main.test.mo
+++ b/test/main.test.mo
@@ -42,7 +42,7 @@ let keysAbsent = gen(n, key_size);
 // Note: bits = 256 and pointers = 2 requires smaller n
 let value_sizes = [0, 2];
 let bits = [2, 4, 16];
-let pointers = [2, 4, 5, 6, 8];
+let pointers = [2, 3, 4, 5, 6, 8];
 for (value_size in value_sizes.vals()) {
   let values = gen(n, value_size);
   for (bit in bits.vals()) {

--- a/test/resize.test.mo
+++ b/test/resize.test.mo
@@ -148,8 +148,8 @@ func refused(s : ?Map.ResizeState) : Bool = switch s {
 };
 
 assert refused(m.beginResize(4)); // no-op (same pointer_size)
-assert refused(m.beginResize(3)); // invalid
 assert refused(m.beginResize(7)); // invalid
+assert refused(m.beginResize(9)); // invalid
 assert refused(m.beginResize(0)); // invalid
 
 // ─── Edge size: empty trie ────────────────────────────────────────────────
@@ -328,4 +328,88 @@ do {
   let leaves_after = rm_now.leaves_region.loadBlob(0, leaves_used);
   assert nodes_before == nodes_after;
   assert leaves_before == leaves_after;
+};
+
+// ─── ps=3: round-trip 4 → 3 → 2 → 3 → 4 ────────────────────────────────────
+//
+// Walks an entry through every shrink/grow combination involving ps=3:
+//   4→3 (shrink), 3→2 (shrink), 2→3 (grow), 3→4 (grow).
+// Verifies the 3-byte (Nat16 + Nat8) pointer encoding round-trips through
+// the wider sizes and works on the receiving side.
+
+do {
+  let pm = Map.empty({
+    pointer_size = 4;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 4;
+    value_size = 4;
+  });
+
+  let N3 = 150;
+  for (i in Nat_.range(0, N3)) {
+    pm.add(keyOf(i), valueOf(i));
+  };
+  // Mix in some deletes so the leaves free list is non-empty across migrations.
+  assert pm.delete(keyOf(10));
+  assert pm.delete(keyOf(20));
+  let live = N3 - 2;
+
+  var p_now : Map.Map = pm;
+
+  // 4 → 3 (shrink, batches of 7).
+  p_now := resize(p_now, 3, 7);
+  assert p_now.size() == live;
+  assert p_now.pointer_size == 3;
+  for (i in Nat_.range(0, N3)) {
+    if (i == 10 or i == 20) {
+      assert p_now.get(keyOf(i)) == null;
+    } else {
+      assert p_now.get(keyOf(i)) == ?valueOf(i);
+    };
+  };
+  // New write at ps=3 reuses a slot from the leaves free list.
+  let leaf_count_3 = p_now.leaf_count;
+  p_now.add(keyOf(10), valueOf(10));
+  assert p_now.leaf_count == leaf_count_3; // reuse, not new allocation
+  assert p_now.get(keyOf(10)) == ?valueOf(10);
+
+  // 3 → 2 (shrink further, batches of 11).
+  p_now := resize(p_now, 2, 11);
+  assert p_now.size() == live + 1;
+  assert p_now.pointer_size == 2;
+  for (i in Nat_.range(0, N3)) {
+    if (i == 20) {
+      assert p_now.get(keyOf(i)) == null;
+    } else {
+      assert p_now.get(keyOf(i)) == ?valueOf(i);
+    };
+  };
+
+  // 2 → 3 (grow, batches of 5).
+  p_now := resize(p_now, 3, 5);
+  assert p_now.size() == live + 1;
+  assert p_now.pointer_size == 3;
+  for (i in Nat_.range(0, N3)) {
+    if (i == 20) {
+      assert p_now.get(keyOf(i)) == null;
+    } else {
+      assert p_now.get(keyOf(i)) == ?valueOf(i);
+    };
+  };
+  // New write at ps=3 after grow uses the free list again.
+  p_now.add(keyOf(20), valueOf(20));
+  assert p_now.size() == N3;
+
+  // 3 → 4 (grow back to the original size, batches of 13).
+  p_now := resize(p_now, 4, 13);
+  assert p_now.size() == N3;
+  assert p_now.pointer_size == 4;
+  for (i in Nat_.range(0, N3)) {
+    assert p_now.get(keyOf(i)) == ?valueOf(i);
+  };
+  // New writes after returning to ps=4 still work and don't collide.
+  p_now.add(keyOf(N3), valueOf(N3));
+  assert p_now.size() == N3 + 1;
+  assert p_now.get(keyOf(N3)) == ?valueOf(N3);
 };

--- a/test/resize_enum.test.mo
+++ b/test/resize_enum.test.mo
@@ -83,5 +83,76 @@ func refused(s : ?Enumeration.ResizeState) : Bool = switch s {
 // Same-pointer-size: no-op refusal.
 assert refused(e_now.beginResize(1));
 // Invalid widths.
-assert refused(e_now.beginResize(3));
+assert refused(e_now.beginResize(7));
 assert refused(e_now.beginResize(0));
+
+// ─── ps=3 for Enumeration: 2 → 3 → 4 → 3 → 2 ───────────────────────────────
+//
+// Enumeration has no leaf free list (removeLast retracts via leaf_count),
+// so the ps=3 cases on the leaves side are trivial. What we cover here is
+// the nodes-region rewrite when growing/shrinking through ps=3, plus that
+// the surviving empty_nodes_list still resolves after the migration.
+
+do {
+  // key+value = 8 so leaf_size doesn't block growth to ps=4 (Enumeration's
+  // leaf_size is key_size + value_size, no Map-style padding).
+  let e3 = Enumeration.empty({
+    pointer_size = 2;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 4;
+    value_size = 4;
+  });
+  func keyOfE(i : Nat) : Blob = Blob.fromArray([
+    Nat8.fromNat(i % 256),
+    Nat8.fromNat((i / 256) % 256),
+    0,
+    0,
+  ]);
+  func valOfE(i : Nat) : Blob = Blob.fromArray([
+    Nat8.fromNat(i % 256),
+    0,
+    0,
+    0,
+  ]);
+  for (i in Nat_.range(0, 50)) {
+    ignore e3.add(keyOfE(i), valOfE(i));
+  };
+  // Pop a few so empty_nodes_list is non-empty going into the resize.
+  ignore e3.removeLast();
+  ignore e3.removeLast();
+  let live = 48;
+  assert e3.size() == live;
+
+  var en : Enumeration.Enumeration = e3;
+  func doResize(target : Nat, batch : Nat) {
+    let state = switch (en.beginResize(target)) {
+      case (?s) s;
+      case null { assert false; loop {} };
+    };
+    while (not Enumeration.stepResize(state, batch)) {};
+    en := Enumeration.completeResize(state);
+  };
+
+  doResize(3, 5); // grow 2 → 3
+  assert en.size() == live;
+  assert en.pointer_size == 3;
+  for (i in Nat_.range(0, live)) {
+    assert en.lookup(keyOfE(i)) == ?(valOfE(i), i);
+  };
+
+  doResize(4, 7); // grow 3 → 4
+  assert en.size() == live;
+  assert en.pointer_size == 4;
+
+  doResize(3, 4); // shrink 4 → 3
+  assert en.size() == live;
+  assert en.pointer_size == 3;
+
+  doResize(2, 6); // shrink 3 → 2
+  assert en.size() == live;
+  assert en.pointer_size == 2;
+  for (i in Nat_.range(0, live)) {
+    assert en.lookup(keyOfE(i)) == ?(valOfE(i), i);
+  };
+};

--- a/test/stats.test.mo
+++ b/test/stats.test.mo
@@ -182,3 +182,38 @@ do {
   assert metrics[1] == ("stable_trie_value_size", "", 0);
   assert metrics[2] == ("stable_trie_key_size", "", 8);
 };
+
+// ─── pointer_size = 3: layout sanity + metric tracking ────────────────────
+//
+// ps=3 uses a 2-byte + 1-byte split internally. Exercise that the trie is
+// constructible, that adds/lookups/deletes work, and that the toValue
+// pointer_size metric reflects the chosen width.
+
+do {
+  let m = Map.empty({
+    pointer_size = 3;
+    aridity = 4;
+    root_aridity = null;
+    key_size = 4;
+    value_size = 4;
+  });
+
+  for (i in Nat_.range(0, 200)) {
+    m.add(k4(i), k4(i));
+  };
+  assert m.size() == 200;
+  for (i in Nat_.range(0, 200)) {
+    assert m.get(k4(i)) == ?k4(i);
+  };
+  // Delete + re-add to exercise the leaves free list under ps=3
+  // (leaf_size = max(8, 3) = 8 → 3-byte chain links fit).
+  assert m.delete(k4(50));
+  assert m.get(k4(50)) == null;
+  m.add(k4(50), k4(50));
+  assert m.get(k4(50)) == ?k4(50);
+
+  let metrics = m.toValue().read();
+  assert metrics[0] == ("stable_trie_pointer_size", "", 3);
+  assert metrics[1] == ("stable_trie_value_size", "", 4);
+  assert metrics[2] == ("stable_trie_key_size", "", 4);
+};


### PR DESCRIPTION
- Add support for `pointer_size = 3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pointer_size = 3.
  * Exposed pointer_size/key_size/value_size and new MemoryStats fields as Prometheus metrics via toValue.

* **Documentation**
  * Updated README, examples and CHANGELOG for 0.1.3 to reflect pointer_size = 3 and related behavior.

* **Tests**
  * Expanded tests to cover pointer_size = 3, resize round-trips and stats reporting.

* **Chores**
  * Bumped package version to 0.1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->